### PR TITLE
Remove deprecated on SF 3.1

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -10,19 +10,19 @@ parameters:
 
 services:
     m6_web_php_pm.http_bridge:
-        class: %m6_web_php_pm.bridge.http_kernel.class%
+        class: '%m6_web_php_pm.bridge.http_kernel.class%'
         arguments: [ '@kernel' ]
     
     m6_web_php_pm.react.loop:
-        class: %m6_web_php_pm.react.event_loop.class%
+        class: '%m6_web_php_pm.react.event_loop.class%'
         factory: [ %m6_web_php_pm.react.event_loop_factory.class%, create ]
         
     m6_web_php_pm.react.socket:
-        class: %m6_web_php_pm.react.socket_server.class%
+        class: '%m6_web_php_pm.react.socket_server.class%'
         arguments: [ '@m6_web_php_pm.react.loop' ]
         
     m6_web_php_pm.react.http_server:
-        class: %m6_web_php_pm.react.http_server.class%
+        class: '%m6_web_php_pm.react.http_server.class%'
         arguments: [ '@m6_web_php_pm.react.socket' ]
         calls:
           - [ on, [ 'request', [ '@m6_web_php_pm.http_bridge', 'onRequest' ] ] ]


### PR DESCRIPTION
Not quoting the scalar "%m6_web_php_pm.bridge.http_kernel.class%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 in "/var/www/symfony/vendor/m6web/php-process-manager-bundle/DependencyInjection/../Resources/config/services.yml" on line 13.