### PR TITLE
Fix react/react version for compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^5.5|^7.0",
         "symfony/symfony"                : "^2.7|^3.0",
-        "react/react"                    : "^0.4"
+        "react/react"                    : "0.4.1"
         
     },
     "require-dev": {


### PR DESCRIPTION
Bonjour

Je pense qu'il y a une dépendance cassée avec reactphp

Je ne sais pas si je m'exprime bien mais si l'on compare la version 0.4.4 de reactphp et la version 0.4.1
0.4.4 :
https://github.com/reactphp/http/blob/v0.4.4/src/Server.php#L68

0.4.1 :
https://github.com/reactphp/http/blob/v0.4.1/src/Server.php#L61

Le emit('data' sur la request est envoyé seulement lorsque le boddy buffer est non vide (et donc pas tout le temps, pas lors d'une simple requete GET)

Hors dans
https://github.com/M6Web/PhpProcessManagerBundle/blob/master/Bridge/HttpKernel.php#L48

Le parti est pris que l'on a systématiquement cet evenement

Donc cela ne marche plus

Si dans votre composer.json on fixe un dependance vers reactphp/react non pas à

    "react/react"                    : "^0.4"
Mais à

    "react/react"                    : "0.4.1"
Il ne devrait plus y avoir de soucis.

Merci pour votre temps

Please, make my application superflight again !